### PR TITLE
fix:  Ensure Custom Domain for Purchase Page

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,3 +14,5 @@ RESEND_API_KEY=re_test_1234
 
 # Env
 NEXT_PUBLIC_LOCAL_URL=http://localhost:3000
+# update this if you config you domain in vercel
+NEXT_PUBLIC_SITE_URL=your_domain


### PR DESCRIPTION
If this environment variable is not set, users will be directed to the Vercel-generated random domain instead of the custom domain when entering the purchase page.

The issue lies in src\utils\get-url.ts.